### PR TITLE
3 mover flag lreadline para variável ldlibs renomear flags para cflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/12/27 14:14:19 by lfarias-          #+#    #+#              #
-#    Updated: 2022/12/27 14:43:01 by lfarias-         ###   ########.fr        #
+#    Updated: 2022/12/27 15:05:35 by lfarias-         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -25,6 +25,9 @@ SRCS		= 	$(addprefix src/,$(SRC))
 OBJS		= 	$(SRCS:.c=.o)
 
 INCLUDES	=	-I ./includes
+
+%.o: %.c
+	@${CC} -c $(CFLAGS) $(INCLUDES) $< -o $@
 
 ${NAME}:   ${OBJS}
 	@${CC} -o ${NAME} ${INCLUDES} ${OBJS} ${CFLAGS} ${LDLIBS}


### PR DESCRIPTION
renomeei FLAGS para CFLAGS (adicionei -g para debug) e movi -lreadline para LDLIBS dessa forma o Makefile ficar mais modularizado e padronizado com as boas práticas.

corrigi o erro de relink que existia nas regras name e all.

adicionei o header da 42 para ficar mais bonitinho e consistente com os outros arquivos no futuro.

Adicionei uma formatação básica afim de melhorar a legibilidade.