### PR TITLE
Add .gitignore with extensive rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+### C ###
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf


### PR DESCRIPTION
Regras para o .gitignore foram adicionadas através do gerador de .gitignore que está no site https://www.toptal.com/developers/gitignore

As regras em si podem ser verificadas/confirmadas aqui:

https://www.toptal.com/developers/gitignore/api/c