### PR TITLE
Builtin Env - fixing builting invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/12/27 14:14:19 by lfarias-          #+#    #+#              #
-#    Updated: 2022/12/29 16:59:52 by lfarias-         ###   ########.fr        #
+#    Updated: 2022/12/29 19:49:13 by mpinna-l         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -18,7 +18,7 @@ CFLAGS		=	-Wall -Werror -Wextra
 
 LDLIBS		= 	-lreadline includes/libft.a
 
-SRC			= 	main.c command_executor.c command_loader.c error_handler.c signal_handlers.c echo.c
+SRC			= 	main.c command_executor.c command_loader.c error_handler.c signal_handlers.c echo.c build_env.c env.c
 
 SRCS		= 	$(addprefix src/,$(SRC))
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mpinna-l <mpinna-l@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/27 16:38:01 by mpinna-l          #+#    #+#             */
-/*   Updated: 2022/12/29 16:58:50 by lfarias-         ###   ########.fr       */
+/*   Updated: 2022/12/29 20:32:56 by mpinna-l         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 # define MINISHELL_H
 
 # define ECHO 1
+# define ENV 2
 
 # include "libft/libft.h"
 # include <stdio.h>
@@ -28,13 +29,18 @@ void	command_executor(char *cmd_path, char **args, char **env);
 
 // builtin
 int		ft_echo(char **args);
+int		ft_env(char **env);
 
 // error handling
 int		print_err_msg(void);
+
+// clone env
+char	**build_env(char **env);
 
 // signals handling
 void	handle_signals(void);
 
 // utils
+int		is_builtin(char *cmd_path);
 void	free2d(void **matrix2d);
 #endif

--- a/src/build_env.c
+++ b/src/build_env.c
@@ -1,0 +1,21 @@
+#include "../includes/minishell.h"
+
+char	**build_env(char **env)
+{
+	int		i;
+	char	**line;
+
+	i = 0;
+	while (env[i])
+		i++;
+	line = malloc(sizeof(char *) * (i + 2));
+	i = 0;
+	while (env[i])
+	{
+		line[i] = ft_strdup(env[i]);
+		i++;
+	}
+	line[i] = NULL;
+	line[i + 1] = NULL;
+	return (line);
+}

--- a/src/command_executor.c
+++ b/src/command_executor.c
@@ -1,7 +1,6 @@
 #include "../includes/minishell.h"
 
-int	is_builtin(char *cmd_path);
-int	execute_builtin(char **args, int builtin_id);
+int	execute_builtin(char **args, char **env, int builtin_id);
 
 void	command_executor(char *cmd_path, char **args, char **env)
 {
@@ -14,7 +13,7 @@ void	command_executor(char *cmd_path, char **args, char **env)
 	builtin_id = is_builtin(cmd_path);
 	if (builtin_id != -1)
 	{
-		execute_builtin(args, builtin_id);
+		execute_builtin(args, env, builtin_id);
 		return ;
 	}
 	pid = fork();
@@ -43,6 +42,8 @@ int	is_builtin(char *cmd_path)
 {
 	if (strncmp(cmd_path, "echo", 4) == 0)
 		return (ECHO);
+	if (strncmp(cmd_path, "env", 3) == 0)
+		return (ENV);
 	return (-1);
 }
 
@@ -52,12 +53,14 @@ int	is_builtin(char *cmd_path)
  * return: the builtin functions's return code
 */
 
-int	execute_builtin(char **args, int builtin_id)
+int	execute_builtin(char **args, char **env, int builtin_id)
 {
 	int	op_code;
 
 	op_code = 0;
 	if (builtin_id == ECHO)
 		op_code = ft_echo(args);
-	return (op_code);	
+	if (builtin_id == ENV)
+		op_code = ft_env(env);
+	return (op_code);
 }

--- a/src/command_loader.c
+++ b/src/command_loader.c
@@ -11,12 +11,12 @@ char	**parse_command(char *statement, char **env)
 	char	*fullpath_cmd;
 	int		i;
 
-	if (!statement || !*statement)
-		return (NULL);
 	cmd_fields = ft_split(statement, ' ');
 	if (cmd_fields == NULL)
 		return (NULL);
 	cmd_name = cmd_fields[0];
+	if (is_builtin(cmd_fields[0]) != -1)
+		return (cmd_fields);
 	if (access(cmd_name, X_OK) == 0)
 		return (cmd_fields);
 	i = 0;

--- a/src/env.c
+++ b/src/env.c
@@ -1,0 +1,13 @@
+#include "../includes/minishell.h"
+
+int	ft_env(char **env)
+{
+	int	i;
+
+	i = 0;
+	if (!env || !*env)
+		return (0);
+	while (env[i])
+		printf("%s\n", env[i++]);
+	return (0);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: mpinna-l <mpinna-l@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/27 08:46:06 by mpinna-l          #+#    #+#             */
-/*   Updated: 2022/12/29 14:26:46 by mpinna-l         ###   ########.fr       */
+/*   Updated: 2022/12/29 20:06:50 by mpinna-l         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,19 +16,21 @@ int	main(int argc, char **argv, char **env)
 {
 	char	*read_line_buffer;
 	char	**cmd;
+	char	**clone_env;
 
 	(void)argv;
 	if (argc != 1)
 		return (1);
 	handle_signals();
+	clone_env = build_env(env);
 	while (42)
 	{
 		read_line_buffer = readline("Minishell> ");
 		if (read_line_buffer && *read_line_buffer)
 		{
 			add_history(read_line_buffer);
-			cmd = parse_command(read_line_buffer, env);
-			command_executor(cmd[0], cmd, env);
+			cmd = parse_command(read_line_buffer, clone_env);
+			command_executor(cmd[0], cmd, clone_env);
 			free2d((void **) cmd);
 		}
 		free(read_line_buffer);

--- a/src/signal_handlers.c
+++ b/src/signal_handlers.c
@@ -2,7 +2,9 @@
 
 void	sigint_handler(int signo)
 {
-	int i = 42;
+	int	i;
+
+	i = 42;
 	wait(&i);
 	if (signo == SIGINT && (i == 42))
 	{
@@ -26,5 +28,3 @@ void	handle_signals(void)
 	signal(SIGINT, sigint_handler);
 	signal(SIGQUIT, sigint_handler);
 }
-
-


### PR DESCRIPTION
Adição de mais um built in.

Neste caso foi o env e para fazer isso foi preciso criar uma função que pudesse clonar o env da máquina principal e trazer ele pro programa. Dessa forma, dali em diante usaremos apenas essa variavel como base para nosso ambiente. Após ter o env clonado bastou imprimir em loop toda a matriz.

Por fim corrigimos um problema em que a logica estava buscando os builtins no path.