### PR TITLE
16 builtin pwd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/12/27 14:14:19 by lfarias-          #+#    #+#              #
-#    Updated: 2022/12/29 19:49:13 by mpinna-l         ###   ########.fr        #
+#    Updated: 2022/12/29 23:09:05 by lfarias-         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -14,11 +14,12 @@ NAME		=	minishell
 
 CC			= 	cc
 
-CFLAGS		=	-Wall -Werror -Wextra 
+CFLAGS		=	-Wall -Werror -Wextra -fsanitize=address 
 
 LDLIBS		= 	-lreadline includes/libft.a
 
-SRC			= 	main.c command_executor.c command_loader.c error_handler.c signal_handlers.c echo.c exit.c build_env.c env.c
+SRC			= 	main.c command_executor.c command_loader.c error_handler.c \
+				signal_handlers.c echo.c exit.c build_env.c env.c pwd.c
 
 SRCS		= 	$(addprefix src/,$(SRC))
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mpinna-l <mpinna-l@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/27 16:38:01 by mpinna-l          #+#    #+#             */
-/*   Updated: 2022/12/29 20:32:56 by mpinna-l         ###   ########.fr       */
+/*   Updated: 2022/12/29 23:05:10 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 
 # define ECHO 1
 # define ENV 2
+# define PWD 3
 # define EXIT 21
 
 # include "libft/libft.h"
@@ -32,6 +33,7 @@ void	command_executor(char *cmd_path, char **args, char **env);
 int		ft_echo(char **args);
 int		ft_exit(char **args);
 int		ft_env(char **env);
+int		ft_pwd(char **args, char **env);
 
 // error handling
 int		print_err_msg(void);

--- a/src/command_executor.c
+++ b/src/command_executor.c
@@ -46,6 +46,8 @@ int	is_builtin(char *cmd_path)
 		return (EXIT);
 	if (strncmp(cmd_path, "env", 3) == 0)
 		return (ENV);
+	if (strncmp(cmd_path, "pwd", 3) == 0)
+		return (PWD);
 	return (-1);
 }
 
@@ -61,10 +63,12 @@ int	execute_builtin(char **args, char **env, int builtin_id)
 
 	op_code = 0;
 	if (builtin_id == ECHO)
-		op_code = ft_echo(args)
+		op_code = ft_echo(args);
 	if (builtin_id == EXIT)
 		ft_exit(args);
 	if (builtin_id == ENV)
 		op_code = ft_env(env);
+	if (builtin_id == PWD)
+		op_code = ft_pwd(args, env);
 	return (op_code);
 }

--- a/src/pwd.c
+++ b/src/pwd.c
@@ -1,0 +1,62 @@
+#include "../includes/minishell.h"
+
+int	fallback_pwd(char **env);
+
+/*
+*	description: will print the current directory
+*	args: none
+*	return: on success 0, on failure 1 (no permission, corrupt dirs, etc)
+*/
+
+int	ft_pwd(char **args, char **env)
+{
+	int		i;
+	int		op_code;
+	char	*curr_dir;
+
+	i = 0;
+	curr_dir = NULL;
+	while (args[i])
+		i++;
+	if (i > 1)
+	{
+		// TO-DO: print this on STDERROR
+		printf("pwd: too many arguments\n");
+		return (1);
+	}
+	curr_dir = getcwd(NULL, 0);
+	if (curr_dir != NULL)
+	{
+		printf("%s\n", curr_dir);
+		free(curr_dir);
+		return (0);
+	}
+	op_code = fallback_pwd(env);
+	return (op_code);
+}
+
+/*
+*	description: if getcwd fails will use the PWD env var as a fallback
+*	args: env - the enviroment variables table
+*	output: if PWD exists will use its value to print it, if not print error
+*	return: on success 0, on error 1
+*/
+
+int	fallback_pwd(char **env)
+{
+	int	i;
+
+	i = 0;
+	while (env[i] && ft_strncmp("PWD=", env[i], 4) != 0)
+		i++;
+	if (env[i] != NULL)
+	{
+		printf("%s\n", &env[i][4]);
+		return (0);
+	}
+	else
+	{
+		print_err_msg();
+		return (1);
+	}	
+}

--- a/src/pwd.c
+++ b/src/pwd.c
@@ -4,7 +4,8 @@ int	fallback_pwd(char **env);
 
 /*
 *	description: will print the current directory
-*	args: none
+*	args: args - to see if it was invoked with invalid args
+*		  env - the env table
 *	return: on success 0, on failure 1 (no permission, corrupt dirs, etc)
 */
 


### PR DESCRIPTION
pwd está implementado.

pwd usa a função `getcwd` como fonte primária para exibir o diretório atual, caso haja algum erro (permissões, diretório corrompido, etc)  então getcwd retorna `NULL` e usamos a variável de ambiente `PWD` para exibir o diretório atual.
Caso a variável não exista, então imprimimos erro.

São necessários mais testes e uma formatação das mensagens de erro mas a funcionalidade básico eu acredito estar bem robusta. 