### PR TITLE
Export builtin + Ctrl - D treatment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/12/27 14:14:19 by lfarias-          #+#    #+#              #
-#    Updated: 2022/12/29 23:09:05 by lfarias-         ###   ########.fr        #
+#    Updated: 2022/12/30 08:15:48 by mpinna-l         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -14,12 +14,13 @@ NAME		=	minishell
 
 CC			= 	cc
 
-CFLAGS		=	-Wall -Werror -Wextra -fsanitize=address 
+CFLAGS		=	-Wall -Werror -Wextra #-fsanitize=address 
 
 LDLIBS		= 	-lreadline includes/libft.a
 
 SRC			= 	main.c command_executor.c command_loader.c error_handler.c \
-				signal_handlers.c echo.c exit.c build_env.c env.c pwd.c
+				signal_handlers.c echo.c exit.c build_env.c env.c pwd.c \
+				export.c
 
 SRCS		= 	$(addprefix src/,$(SRC))
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mpinna-l <mpinna-l@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/27 16:38:01 by mpinna-l          #+#    #+#             */
-/*   Updated: 2022/12/29 23:05:10 by lfarias-         ###   ########.fr       */
+/*   Updated: 2022/12/30 10:06:52 by mpinna-l         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,7 @@
 # define ENV 2
 # define PWD 3
 # define EXIT 21
+# define EXPORT 4
 
 # include "libft/libft.h"
 # include <stdio.h>
@@ -26,14 +27,20 @@
 # include <signal.h>
 # include <sys/wait.h>
 
+typedef struct s_env
+{
+	char **env;
+} t_env;
+
 char	**parse_command(char *statement, char **env);
-void	command_executor(char *cmd_path, char **args, char **env);
+void	command_executor(char *cmd_path, char **args, t_env *env);
 
 // builtin
 int		ft_echo(char **args);
 int		ft_exit(char **args);
 int		ft_env(char **env);
 int		ft_pwd(char **args, char **env);
+int		ft_export(char **args, t_env *env);
 
 // error handling
 int		print_err_msg(void);

--- a/src/build_env.c
+++ b/src/build_env.c
@@ -8,7 +8,7 @@ char	**build_env(char **env)
 	i = 0;
 	while (env[i])
 		i++;
-	line = malloc(sizeof(char *) * (i + 2));
+	line = malloc(sizeof(char *) * (i + 1));
 	i = 0;
 	while (env[i])
 	{
@@ -16,6 +16,5 @@ char	**build_env(char **env)
 		i++;
 	}
 	line[i] = NULL;
-	line[i + 1] = NULL;
 	return (line);
 }

--- a/src/command_executor.c
+++ b/src/command_executor.c
@@ -1,8 +1,8 @@
 #include "../includes/minishell.h"
 
-int	execute_builtin(char **args, char **env, int builtin_id);
+int	execute_builtin(char **args, t_env *env, int builtin_id);
 
-void	command_executor(char *cmd_path, char **args, char **env)
+void	command_executor(char *cmd_path, char **args, t_env *env)
 {
 	int	pid;
 	int	wstatus;
@@ -24,7 +24,7 @@ void	command_executor(char *cmd_path, char **args, char **env)
 	}
 	if (pid == 0)
 	{
-		if (execve(cmd_path, args, env) == -1)
+		if (execve(cmd_path, args, env->env) == -1)
 			print_err_msg();
 		exit(0);
 	}	
@@ -48,6 +48,8 @@ int	is_builtin(char *cmd_path)
 		return (ENV);
 	if (strncmp(cmd_path, "pwd", 3) == 0)
 		return (PWD);
+	if (strncmp(cmd_path, "export", 6) == 0)
+		return (EXPORT);
 	return (-1);
 }
 
@@ -57,7 +59,7 @@ int	is_builtin(char *cmd_path)
  * return: the builtin functions's return code
 */
 
-int	execute_builtin(char **args, char **env, int builtin_id)
+int	execute_builtin(char **args, t_env *env, int builtin_id)
 {
 	int	op_code;
 
@@ -67,8 +69,10 @@ int	execute_builtin(char **args, char **env, int builtin_id)
 	if (builtin_id == EXIT)
 		ft_exit(args);
 	if (builtin_id == ENV)
-		op_code = ft_env(env);
+		op_code = ft_env(env->env);
 	if (builtin_id == PWD)
-		op_code = ft_pwd(args, env);
+		op_code = ft_pwd(args, env->env);
+	if (builtin_id == EXPORT)
+		op_code = ft_export(args, env);
 	return (op_code);
 }

--- a/src/exit.c
+++ b/src/exit.c
@@ -6,7 +6,7 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/29 17:47:37 by lfarias-          #+#    #+#             */
-/*   Updated: 2022/12/29 19:01:20 by lfarias-         ###   ########.fr       */
+/*   Updated: 2022/12/30 10:45:37 by mpinna-l         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,7 +37,7 @@ int	ft_exit(char **args)
 		return (1);
 	}
 	exit_code = convert_to_range(args[1]);
-	exit (exit_code);	
+	exit (exit_code);
 	return (0);
 }
 
@@ -48,7 +48,7 @@ int	ft_exit(char **args)
 int	convert_to_range(char *arg)
 {
 	long	number;
-	
+
 	if (arg == NULL)
 		return (0);
 	number = ft_atoi(arg);

--- a/src/export.c
+++ b/src/export.c
@@ -1,0 +1,29 @@
+#include "../includes/minishell.h"
+
+int	ft_export(char **args, t_env *env)
+{
+	int		i;
+	char	**new_env;
+
+	i = 0;
+	if (!args[1])
+		return (ft_env(env->env));
+	while (env->env[i])
+		i++;
+	new_env = malloc(sizeof(char *) * (i + 2));
+	i = 0;
+	while (env->env[i])
+	{
+		new_env[i] = ft_strdup(env->env[i]);
+		free(env->env[i++]);
+	}
+	free(env->env[i]);
+	free(env->env);
+	if (args[1])
+		if (!ft_isdigit(args[1][0]))
+			new_env[i++] = ft_strdup(args[1]);
+	new_env[i] = NULL;
+	env->env = new_env;
+	i = 0;
+	return (0);
+}	

--- a/src/main.c
+++ b/src/main.c
@@ -6,34 +6,44 @@
 /*   By: mpinna-l <mpinna-l@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/27 08:46:06 by mpinna-l          #+#    #+#             */
-/*   Updated: 2022/12/29 20:06:50 by mpinna-l         ###   ########.fr       */
+/*   Updated: 2022/12/30 10:44:20 by mpinna-l         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
 
+void	handle_eof(char *input)
+{
+	free(input);
+	if (!input)
+	{
+		printf("exit\n");
+		exit(0);
+	}
+}
+
 int	main(int argc, char **argv, char **env)
 {
 	char	*read_line_buffer;
 	char	**cmd;
-	char	**clone_env;
+	t_env	env_test;
 
 	(void)argv;
 	if (argc != 1)
 		return (1);
 	handle_signals();
-	clone_env = build_env(env);
+	env_test.env = build_env(env);
 	while (42)
 	{
 		read_line_buffer = readline("Minishell> ");
 		if (read_line_buffer && *read_line_buffer)
 		{
 			add_history(read_line_buffer);
-			cmd = parse_command(read_line_buffer, clone_env);
-			command_executor(cmd[0], cmd, clone_env);
+			cmd = parse_command(read_line_buffer, env_test.env);
+			command_executor(cmd[0], cmd, &env_test);
 			free2d((void **) cmd);
 		}
-		free(read_line_buffer);
+		handle_eof(read_line_buffer);
 	}
 	rl_clear_history();
 	return (0);


### PR DESCRIPTION
Implementei o comando export, porém sem a tratativa de erros específicos por enquanto.
Por enquanto ele está funcionando mandando o argumento para env.

Criei uma estrutura porque com o env antigo as alterações realizadas nas funções estavam sendo desprezadas
fazendo com que o env nunca atualizasse depois das funções. Agora eu alterei algumas funções para receber o endereço
de t_env env. 

Aproveitei também para  tratar o ctrl+D que faz com que o shell exit caso o prompt esteja vazio.
Adcionei uma função em cima da main chamada handle_eof que faz esse trabalho.

O ctrl+D representa o EOF e é lido pelo readline como (NULL) então foi assim que consegui identifica-lo.