### PR TITLE
47 bug melhorias em unset

### DIFF
--- a/src/unset.c
+++ b/src/unset.c
@@ -1,30 +1,91 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   unset.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/01/06 19:10:02 by lfarias-          #+#    #+#             */
+/*   Updated: 2023/01/06 20:14:08 by lfarias-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "../includes/minishell.h"
+
+int		is_valid_identifier(char *identifier);
+char	**create_env(char **env);
+char	**del_variable(char *var_name, char **old_env);
 
 int	ft_unset(char **args, t_env *env)
 {
-	int		i;
-	char	**new_env;
-	int		j;
-	char	*arg;
+	char	**vars;
 
-	i = 0;
-	while (env->env[i])
-		i++;
-	if (!args[1])
-		return (0);
-	arg = ft_strjoin(args[1], "=");
-	new_env = malloc(sizeof(char *) * (i));
+	vars = args;
+	while (*vars)
+	{
+		if (!is_valid_identifier(*vars))
+		{
+			vars++;
+			continue ;
+		}
+		env->env = del_variable(*vars, env->env);
+		vars++;
+	}
+	return (0);
+}
+
+char	**del_variable(char *var_name, char **old_env)
+{
+	char	**new_env;
+	int		i;
+	int		j;
+
+	if (!var_name || !old_env)
+		return (NULL);
 	i = 0;
 	j = 0;
-	while (env->env[i])
+	new_env = create_env(old_env);
+	var_name = ft_strjoin(var_name, "=");
+	while (old_env[i])
 	{
-		if (ft_strncmp(arg, env->env[i], ft_strlen(arg)))
-			new_env[j++] = ft_strdup(env->env[i]);
-		free(env->env[i++]);
-	}
-	free(env->env);
-	free(arg);
+		if (ft_strncmp(var_name, old_env[i], ft_strlen(var_name)))
+			new_env[j++] = ft_strdup(old_env[i]);
+		free(old_env[i++]);
+	}			
+	free(old_env);
+	free(var_name);
 	new_env[j] = NULL;
-	env->env = new_env;
-	return (0);
+	return (new_env);
+}
+
+int	is_valid_identifier(char *identifier)
+{
+	int	i;
+
+	i = 0;
+	if (!(ft_isalpha(identifier[i]) || identifier[i] == '_'))
+		return (0);
+	i++;
+	while (identifier[i])
+	{
+		if (ft_isalnum(identifier[i]) || identifier[i] == '_')
+			i++;
+		else
+			return (0);
+	}
+	return (1);
+}
+
+char	**create_env(char **env)
+{
+	int		i;
+	char	**new_env;
+
+	i = 0;
+	while (env[i])
+		i++;
+	new_env = malloc(sizeof(char *) * (i + 1));
+	if (!new_env)
+		return (NULL);
+	return (new_env);
 }

--- a/src/unset.c
+++ b/src/unset.c
@@ -6,7 +6,7 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/06 19:10:02 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/01/06 20:14:08 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/01/06 20:23:48 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,24 +36,27 @@ int	ft_unset(char **args, t_env *env)
 
 char	**del_variable(char *var_name, char **old_env)
 {
-	char	**new_env;
-	int		i;
-	int		j;
+	char		**new_env;
+	int			i;
+	int			j;
+	size_t		var_length;
 
 	if (!var_name || !old_env)
 		return (NULL);
 	i = 0;
 	j = 0;
+	var_length = ft_strlen(var_name);
 	new_env = create_env(old_env);
-	var_name = ft_strjoin(var_name, "=");
 	while (old_env[i])
 	{
-		if (ft_strncmp(var_name, old_env[i], ft_strlen(var_name)))
+		if (ft_strncmp(var_name, old_env[i], var_length) \
+			&& var_length != ft_strlen(old_env[i]))
+		{
 			new_env[j++] = ft_strdup(old_env[i]);
+		}
 		free(old_env[i++]);
 	}			
 	free(old_env);
-	free(var_name);
 	new_env[j] = NULL;
 	return (new_env);
 }


### PR DESCRIPTION
`unset` refatorado para aceitar múltiplas variáveis 

o código de retorno sempre retorna 0 mesmo que uma variável não exista ou seja um identificador inválido

mesmo que múltiplas variáveis sejam informadas e uma dela seja inválida, `unset` irá apagar todas as outras que existam.

Na parte da lógica para encontrar uma variável: agora o tamanho da variável e o resultado de `ft_strncmp` são usados
como critérios. 
Isto foi feito pois uma variável pode ser declarada sem valor, ela não aparece em `env` mas aparece quando `export` é invocado. o algoritmo antigo usava o nome da variável + `=` e isso fazia com que somente variáveis que tivessem um valor fossem deletadas de fato.