### PR TITLE
53 bug conectar quote resolverc e expanderc com o código

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/12/27 14:14:19 by lfarias-          #+#    #+#              #
-#    Updated: 2023/01/07 19:20:43 by mpinna-l         ###   ########.fr        #
+#    Updated: 2023/01/08 20:58:14 by lfarias-         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -25,7 +25,7 @@ LDFLAGS 	=   -L  /Users/lfarias-/.brew/Cellar/readline/8.2.1/lib
 
 SRC			= 	main.c command_executor.c command_loader.c error_handler.c \
 				signal_handlers.c echo.c exit.c build_env.c env.c pwd.c cd.c \
-				export.c expander.c unset.c quote_resolver.c \
+				export.c expander.c expander_utils.c unset.c quote_resolver.c \
 				lexer.c parser.c parser_rules.c interpreter.c pipes.c
 
 SRCS		= 	$(addprefix src/,$(SRC))

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mpinna-l <mpinna-l@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/27 16:38:01 by mpinna-l          #+#    #+#             */
-/*   Updated: 2023/01/07 19:29:42 by mpinna-l         ###   ########.fr       */
+/*   Updated: 2023/01/07 23:57:56 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -108,7 +108,7 @@ int			update_quote(char *str, int i, int *quote_flag);
 
 // Expand variables
 int			valid_variable(char *c);
-char		*expand_variable(char *input, char **env);
+char		*expand_str(char *input, char **env);
 
 // utils
 int			is_builtin(char *cmd_path);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mpinna-l <mpinna-l@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/27 16:38:01 by mpinna-l          #+#    #+#             */
-/*   Updated: 2023/01/07 23:57:56 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/01/08 20:59:21 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -109,6 +109,7 @@ int			update_quote(char *str, int i, int *quote_flag);
 // Expand variables
 int			valid_variable(char *c);
 char		*expand_str(char *input, char **env);
+char		*str_nodes_join(t_list *str_nodes);
 
 // utils
 int			is_builtin(char *cmd_path);

--- a/src/expander.c
+++ b/src/expander.c
@@ -6,13 +6,91 @@
 /*   By: mpinna-l <mpinna-l@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/07 09:29:03 by mpinna-l          #+#    #+#             */
-/*   Updated: 2023/01/08 02:35:28 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/01/08 19:22:06 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
 
 #define ERR_MALLOC 0
+
+char	*expand_variable(char *input, char **env, int *variable_size);
+void	add_var_value(t_list **str_nds, char *input, int *i, char **env);
+char	*str_nodes_join(t_list *str_nodes);
+
+char	*expand_str(char *input, char **env)
+{
+	t_list	*str_nodes;
+	int		str_size;
+	int		i;
+
+	str_size = ft_strlen(input);
+	i = 0;
+	str_nodes = NULL;
+	while (i < str_size)
+	{
+		if (input[i] && input[i] != '$')
+		{
+			ft_lstadd_back(&str_nodes, ft_lstnew(ft_substr(input, i, 1)));
+			i++;
+			continue ;
+		}
+		add_var_value(&str_nodes, input, &i, env);
+	}
+	if (!str_nodes)
+		return (NULL);
+	return (str_nodes_join(str_nodes));
+}
+
+void	add_var_value(t_list **str_nodes, char *input, int *i, char **env)
+{
+	char	*variable;
+	int		variable_size;
+	int		str_size;
+
+	str_size = ft_strlen(input);
+	variable_size = 0;
+	variable = NULL;
+	if (*i < str_size)
+	{
+		variable = expand_variable(&input[*i], env, &variable_size);
+		ft_lstadd_back(str_nodes, ft_lstnew(variable));
+		if (input[*i] == '$' && variable_size == 0)
+			ft_lstadd_back(str_nodes, ft_lstnew(ft_substr(input, *i, 1)));
+		if (variable_size != 0)
+			*i = *i + variable_size + 2;
+		else
+			*i = *i + 1;
+		variable_size = 0;
+	}
+}
+
+char	*expand_variable(char *input, char **env, int *variable_size)
+{
+	int		i;
+	char	*variable;
+
+	i = -1;
+	if (!input)
+		return (NULL);
+	if (*input == '$')
+	{
+		input++;
+		*variable_size = valid_variable(input);
+		if (*variable_size != 0 && *input)
+		{
+			while (env[++i])
+			{
+				if (!ft_strncmp(input, env[i], *variable_size))
+				{
+					variable = ft_strdup(ft_strchr(env[i], '=') + 1);
+					return (variable);
+				}
+			}
+		}	
+	}
+	return (ft_strdup(""));
+}
 
 int	valid_variable(char *c)
 {
@@ -21,6 +99,8 @@ int	valid_variable(char *c)
 	i = 0;
 	while (c[i] && c[i] != '$')
 	{
+		if (c[i + 1] && c[i + 1] == '$')
+			return (i);
 		if (c[i + 1] && c[i + 1] == ' ')
 			return (i);
 		if (c[i] == '=' && i == 0)
@@ -36,33 +116,6 @@ int	valid_variable(char *c)
 	return (i);
 }
 
-char	*expand_variable(char *input, char **env, int *variable_size)
-{
-	int		i;
-	char	*variable;
-
-	i = 0;
-	if (!input)
-		return (NULL);
-	if (*input == '$')
-	{
-		input++;
-		*variable_size = valid_variable(input);
-		if (*variable_size != 0)
-		{
-			while (env[++i])
-			{
-				if (!ft_strncmp(input, env[i], *variable_size))
-				{
-					variable = ft_strdup(ft_strchr(env[i], '=') + 1);
-					return (variable);
-				}
-			}
-		}	
-	}
-	return (NULL);
-}
-
 char	*str_nodes_join(t_list *str_nodes)
 {
 	int		str_size;
@@ -75,7 +128,7 @@ char	*str_nodes_join(t_list *str_nodes)
 		str_size += ft_strlen(((char *) node->content));
 		node = node->next;
 	}
-	expanded_str = ft_calloc(sizeof(char), str_size);
+	expanded_str = ft_calloc(sizeof(char), (str_size + 1));
 	while (str_nodes)
 	{
 		ft_strlcat(expanded_str, (char *) str_nodes->content, str_size);
@@ -87,46 +140,7 @@ char	*str_nodes_join(t_list *str_nodes)
 	return (expanded_str);
 }
 
-char *expand_str(char *input, char **env)
-{
-	t_list	*str_nodes;
-	int		variable_size;
-	char	*variable;
-	int		i;
-	int		j;
-
-	i = 0;
-	j = 0;
-	variable_size = 0;
-	str_nodes = NULL;
-	while (input[i])
-	{
-		variable = expand_variable(&input[i], env, &variable_size);
-		if (variable != NULL)
-		{
-			if ((i - j) > 0)
-				ft_lstadd_back(&str_nodes, ft_lstnew(ft_substr(input, j, (i - j))));
-			ft_lstadd_back(&str_nodes, ft_lstnew(variable));
-			i += (variable_size + 2);
-			j = i;
-		}
-		else
-		{
-			ft_lstadd_back(&str_nodes, ft_lstnew(ft_strdup("")));
-			i += variable_size;
-		}
-		if (input[i + 1] == '\0')
-		{
-			ft_lstadd_back(&str_nodes, ft_lstnew(ft_substr(input, j, i - j)));
-			i++;
-		}
-	}
-	if (!str_nodes)
-		return (NULL);
-	return (str_nodes_join(str_nodes));	
-}
-
-int main (int argc, char **argv, char **env)
+/*int main (int argc, char **argv, char **env)
 {
 	char *var = "$PWD";
 	char *var2 = "$PDW";
@@ -135,6 +149,9 @@ int main (int argc, char **argv, char **env)
 	char *var5 = "$HOME";
 	char *var6 = "$HOME$";
 	char *var7 = "$HOME abc $ABC $abc";
+	char *var8 = "$HOME abc $ABC $abc bca";
+	char *var9 = "$HOME$HOME";
+	char *var10 = "Hello $HOME";
 
 	printf("%s expanded -> %s\n", var, expand_str(var, env));
 	printf("%s expanded -> %s\n", var2, expand_str(var2, env));
@@ -143,4 +160,7 @@ int main (int argc, char **argv, char **env)
 	printf("%s expanded -> %s\n", var5, expand_str(var5, env));
 	printf("%s expanded -> %s\n", var6, expand_str(var6, env));
 	printf("%s expanded -> %s\n", var7, expand_str(var7, env));
-}
+	printf("%s expanded -> %s\n", var8, expand_str(var8, env));
+	printf("%s expanded -> %s\n", var9, expand_str(var9, env));
+	printf("%s expanded -> %s\n", var10, expand_str(var10, env));
+}*/

--- a/src/expander.c
+++ b/src/expander.c
@@ -6,7 +6,7 @@
 /*   By: mpinna-l <mpinna-l@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/07 09:29:03 by mpinna-l          #+#    #+#             */
-/*   Updated: 2023/01/07 19:29:07 by mpinna-l         ###   ########.fr       */
+/*   Updated: 2023/01/08 02:35:28 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,9 +18,11 @@ int	valid_variable(char *c)
 {
 	int	i;
 
-	i = -1;
-	while (c[++i])
+	i = 0;
+	while (c[i] && c[i] != '$')
 	{
+		if (c[i + 1] && c[i + 1] == ' ')
+			return (i);
 		if (c[i] == '=' && i == 0)
 			return (0);
 		else if (c[i] == '=' && i != 0)
@@ -29,11 +31,12 @@ int	valid_variable(char *c)
 			return (0);
 		else if ((!ft_isalpha(c[i]) && !ft_isdigit(c[i]) && !(c[i] == '_')))
 			return (0);
+		i++;
 	}
-	return (1);
+	return (i);
 }
 
-char	*expand_variable(char *input, char **env)
+char	*expand_variable(char *input, char **env, int *variable_size)
 {
 	int		i;
 	char	*variable;
@@ -44,11 +47,12 @@ char	*expand_variable(char *input, char **env)
 	if (*input == '$')
 	{
 		input++;
-		if (valid_variable(input))
+		*variable_size = valid_variable(input);
+		if (*variable_size != 0)
 		{
 			while (env[++i])
 			{
-				if (!ft_strncmp(input, env[i], ft_strlen(input)))
+				if (!ft_strncmp(input, env[i], *variable_size))
 				{
 					variable = ft_strdup(ft_strchr(env[i], '=') + 1);
 					return (variable);
@@ -56,9 +60,72 @@ char	*expand_variable(char *input, char **env)
 			}
 		}	
 	}
-	return (ft_strdup(""));
+	return (NULL);
 }
-/*
+
+char	*str_nodes_join(t_list *str_nodes)
+{
+	int		str_size;
+	t_list	*node;
+	char	*expanded_str;
+
+	node = str_nodes;
+	while (node)
+	{
+		str_size += ft_strlen(((char *) node->content));
+		node = node->next;
+	}
+	expanded_str = ft_calloc(sizeof(char), str_size);
+	while (str_nodes)
+	{
+		ft_strlcat(expanded_str, (char *) str_nodes->content, str_size);
+		node = str_nodes;
+		str_nodes = str_nodes->next;
+		free(node->content);
+		free(node);
+	}
+	return (expanded_str);
+}
+
+char *expand_str(char *input, char **env)
+{
+	t_list	*str_nodes;
+	int		variable_size;
+	char	*variable;
+	int		i;
+	int		j;
+
+	i = 0;
+	j = 0;
+	variable_size = 0;
+	str_nodes = NULL;
+	while (input[i])
+	{
+		variable = expand_variable(&input[i], env, &variable_size);
+		if (variable != NULL)
+		{
+			if ((i - j) > 0)
+				ft_lstadd_back(&str_nodes, ft_lstnew(ft_substr(input, j, (i - j))));
+			ft_lstadd_back(&str_nodes, ft_lstnew(variable));
+			i += (variable_size + 2);
+			j = i;
+		}
+		else
+		{
+			ft_lstadd_back(&str_nodes, ft_lstnew(ft_strdup("")));
+			i += variable_size;
+		}
+		if (input[i + 1] == '\0')
+		{
+			ft_lstadd_back(&str_nodes, ft_lstnew(ft_substr(input, j, i - j)));
+			i++;
+		}
+	}
+	if (!str_nodes)
+		return (NULL);
+	return (str_nodes_join(str_nodes));	
+}
+
 int main (int argc, char **argv, char **env)
 {
 	char *var = "$PWD";
@@ -67,11 +134,13 @@ int main (int argc, char **argv, char **env)
 	char *var4 = "$123";
 	char *var5 = "$HOME";
 	char *var6 = "$HOME$";
+	char *var7 = "$HOME abc $ABC $abc";
 
-	printf("%s expanded -> %s\n", var, expand_variable(var, env));
-	printf("%s expanded -> %s\n", var2, expand_variable(var2, env));
-	printf("%s expanded -> %s\n", var3, expand_variable(var3, env));
-	printf("%s expanded -> %s\n", var4, expand_variable(var4, env));
-	printf("%s expanded -> %s\n", var5, expand_variable(var5, env));
-	printf("%s expanded -> %s\n", var6, expand_variable(var6, env));
-}*/
+	printf("%s expanded -> %s\n", var, expand_str(var, env));
+	printf("%s expanded -> %s\n", var2, expand_str(var2, env));
+	printf("%s expanded -> %s\n", var3, expand_str(var3, env));
+	printf("%s expanded -> %s\n", var4, expand_str(var4, env));
+	printf("%s expanded -> %s\n", var5, expand_str(var5, env));
+	printf("%s expanded -> %s\n", var6, expand_str(var6, env));
+	printf("%s expanded -> %s\n", var7, expand_str(var7, env));
+}

--- a/src/expander_utils.c
+++ b/src/expander_utils.c
@@ -1,0 +1,37 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expander_utils.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/01/08 20:55:20 by lfarias-          #+#    #+#             */
+/*   Updated: 2023/01/08 20:56:53 by lfarias-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/minishell.h"
+
+char	*str_nodes_join(t_list *str_nodes)
+{
+	int		str_size;
+	t_list	*node;
+	char	*expanded_str;
+
+	node = str_nodes;
+	while (node)
+	{
+		str_size += ft_strlen(((char *) node->content));
+		node = node->next;
+	}
+	expanded_str = ft_calloc(sizeof(char), (str_size + 1));
+	while (str_nodes)
+	{
+		ft_strlcat(expanded_str, (char *) str_nodes->content, str_size);
+		node = str_nodes;
+		str_nodes = str_nodes->next;
+		free(node->content);
+		free(node);
+	}
+	return (expanded_str);
+}

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -6,13 +6,14 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/05 22:43:16 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/01/07 20:02:36 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/01/07 22:44:49 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
 
-char	**command_builder(t_command *expr);
+char	**command_builder(t_command *expr, char **env);
+char	*args_eval(char *arg, char **env);
 int		count_fields(t_command *expr);
 
 //printf("token value: %s\n", ((t_token *) (*tokens)->content)->value);
@@ -33,7 +34,7 @@ void	eval_tokens(t_list **tokens, t_env *env_clone)
 		expr = parse_expression(tokens);
 		if (expr == NULL)
 			break ;
-		cmd = command_builder(expr);
+		cmd = command_builder(expr, env_clone->env);
 		if (cmd == NULL)
 			break ;
 		expr->in_pipe[0] = prev_pipe[0];
@@ -65,7 +66,7 @@ int	count_fields(t_command *expr)
 	return (i);
 }
 
-char	**command_builder(t_command *expr)
+char	**command_builder(t_command *expr, char **env)
 {
 	char	**cmd;
 	int		field_count;
@@ -80,7 +81,7 @@ char	**command_builder(t_command *expr)
 	i = 0;
 	while (expr->tokens[i] != NULL && expr->tokens[i]->type != PIPE)
 	{
-		cmd[i] = expr->tokens[i]->value;
+		cmd[i] = args_eval(expr->tokens[i]->value, env);
 		free(expr->tokens[i]);
 		i++;
 	}
@@ -92,4 +93,18 @@ char	**command_builder(t_command *expr)
 	free(expr->tokens);
 	cmd[i] = NULL;
 	return (cmd);
+}
+
+char	*args_eval(char *arg, char **env)
+{
+	char	*temp;
+
+	(void)env;
+	temp = quote_resolver(arg);
+	if (temp != NULL)
+	{
+		free(arg);
+		arg = temp;
+	}
+	return (arg);
 }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -6,7 +6,7 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/05 22:43:16 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/01/08 00:00:28 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/01/08 19:59:34 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -99,14 +99,13 @@ char	*args_eval(char *arg, char **env)
 {
 	char	*temp;
 
-	(void)env;
-	temp = quote_resolver(arg);
+	temp = expand_str(arg, env);
 	if (temp != NULL)
 	{
 		free(arg);
 		arg = temp;
 	}
-	temp = expand_str(arg, env);
+	temp = quote_resolver(arg);
 	if (temp != NULL)
 	{
 		free(arg);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -6,7 +6,7 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/05 22:43:16 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/01/07 22:44:49 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/01/08 00:00:28 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -101,6 +101,12 @@ char	*args_eval(char *arg, char **env)
 
 	(void)env;
 	temp = quote_resolver(arg);
+	if (temp != NULL)
+	{
+		free(arg);
+		arg = temp;
+	}
+	temp = expand_str(arg, env);
 	if (temp != NULL)
 	{
 		free(arg);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -6,7 +6,7 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/04 18:33:43 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/01/06 01:08:51 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/01/07 22:47:07 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,10 +19,24 @@ int	is_operator(char c)
 	return (0);
 }
 
+void quote_interruptor(char c, int *is_on)
+{
+	if (c == '\'' && *is_on == 0)
+		*is_on = 1;
+	else if (c == '\'' && *is_on == 1)
+		*is_on = 0;
+	else if (c == '"' && *is_on == 0)
+		*is_on = 2;
+	else if (c == '"' && *is_on == 2)
+		*is_on = 0;
+}
+
 int	get_token_size(char *str)
 {
 	int	i;
+	int	quote_on;
 
+	quote_on = 0;
 	i = 0;
 	if (str[i] && is_operator(str[i]))
 	{	
@@ -34,8 +48,12 @@ int	get_token_size(char *str)
 		i++;
 		return (i);
 	}
-	while (str[i] && (!is_operator(str[i]) && !ft_isspace(str[i])))
+	while (str[i] && \
+		(quote_on || (!is_operator(str[i]) && !ft_isspace(str[i]))))
+	{
+		quote_interruptor(str[i], &quote_on);
 		i++;
+	}
 	return (i);
 }
 


### PR DESCRIPTION
Após muito custo o código já consegue lidar com a expansão de variáveis de ambiente e com aspas simples (') e aspas duplas (") faltam mais testes e talvez o código quebre em algum edge case. mas para uma versão v0.1 já está bem aceitável.

Usando a lógica do expand_variable, usei a opção 'nuclear' e dividi a string toda em pequenos blocos que foram guardados em uma lista linkada. onde há uma string que é variável ele retorna o valor e adiciona a lista e pula o tamanho em caracteres desta variável dentro da string. onde não haja valor então uma string vazia será retornada e também adicionada a lista. ao final percorremos a lista inteira concatenando as strings em cada nó.

Durante a expansão há uma lógica somente para verificar se a string é expandível ou não que irá determinar se iremos colocar o valor da variável valida ou ela mesmo.